### PR TITLE
fix compilation on OSG 3.6

### DIFF
--- a/src/WriterCompareTriangle.cpp
+++ b/src/WriterCompareTriangle.cpp
@@ -1,9 +1,19 @@
 #include "WriterCompareTriangle.h"
 
+static osg::BoundingBox toBoundingBox(osg::BoundingSphere const& sphere) {
+    osg::BoundingBox box;
+    box.expandBy(sphere);
+    return box;
+}
+
+static osg::BoundingBox toBoundingBox(osg::BoundingBox const& box) {
+    return box;
+}
+
 WriterCompareTriangle::WriterCompareTriangle(const osg::Geode& in_geode, unsigned int in_nbVertices):
         geode(geode)
 {
-    cutscene(in_nbVertices, geode.getDrawable(0)->asGeometry()->getBound());
+    cutscene(in_nbVertices, toBoundingBox(geode.getDrawable(0)->asGeometry()->getBound()));
 }
 
 bool


### PR DESCRIPTION
Note that we'd rather have to pull the source code from the plugin
out of the 3.6 tree. Do this for now.